### PR TITLE
Create README development instructions and a WIP warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,24 @@ Step-up API
 
 This component is part of "Step-up Middleware". See [Stepup-Deploy](https://github.com/OpenConext/Stepup-Deploy) for an overview and installation instructions for a complete Stepup system, including this component. The requirements and installation instructions below cover this component only.
 
+## Warning :warning:
+
+This project is currently a work in progress and is being used as a proof of concept. This means that it might not (fully) work yet.
+
 ## Requirements
 
-* PHP 7.2+
+* PHP 8.1+
 * [Composer](https://getcomposer.org/)
 * A web server (Apache, Nginx)
 * A working [Middleware](https://github.com/OpenConext/Stepup-Middleware)
+* Docker
+* Docker Compose
+
+## For developers
+
+To create a development environment for this project, the following commands need to be executed:
+
+```bash
+$ docker compose up -d
+$ docker compose exec stepup-api -c 'composer install'
+```


### PR DESCRIPTION
To make the repository from private to public, the README has been updated. This to reflect the new project environment (PHP 8.1+) and to warn possible users that this project is still a work in progress.