### PR TITLE
Add archive options to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,5 +68,18 @@
             "allow-contrib": false,
             "require": "6.3.*"
         }
+    },
+    "archive": {
+        "exclude": [
+            "*",
+            ".*",
+            "!/bin",
+            "!/component_info",
+            "!/config",
+            "!/public",
+            "!/src",
+            "!/var/cache/prod",
+            "!/vendor"
+        ]
     }
 }


### PR DESCRIPTION
I have added archive options to the composer.json, since the most recent GHA build (probably) failed due to this part missing.